### PR TITLE
fix: Correct typo

### DIFF
--- a/components/sections/home-page/Logos.tsx
+++ b/components/sections/home-page/Logos.tsx
@@ -16,7 +16,7 @@ const Logos = ({ data }: LogosProps) => {
       <ContainerWithLine>
         <div className="px-6 pt-32 pb-4 largeTablet:pt-10 ">
           <Typography alignLarge="left" alignSmall="center" variant="preHeading">
-            TRUSTED BT
+            TRUSTED BY
           </Typography>
         </div>
         <div className="w-full px-6 pb-40 grid grid-cols-3 gap-x-10 gap-y-8 justify-center items-center content-center largeTablet:mt-0 largeTablet:grid-cols-6">


### PR DESCRIPTION
Hello! Saw a small typo on the landing page and wanted to throw a quick pr for you all!

Changes the text "Trusted Bt" to "Trusted By"

From:
![Screenshot from 2023-05-23 22-50-33](https://github.com/open-sauced/landing-page/assets/69019114/5a22690c-b44b-4959-aea3-77659a87c239)

To:
![Screenshot from 2023-05-23 22-50-41](https://github.com/open-sauced/landing-page/assets/69019114/7117169e-444c-4100-8e7a-4e71e44c5926)
