### PR TITLE
fix: sanity/tsconfig.json error

### DIFF
--- a/sanity/tsconfig.json
+++ b/sanity/tsconfig.json
@@ -2,23 +2,8 @@
   "compilerOptions": {
     "jsx": "react"
   },
-  "compilerOptions": {
-    "jsx": "react"
-  },
-  "compilerOptions": {
-    "jsx": "react"
-  },
-  "compilerOptions": {
-    "jsx": "react"
-  },
-  "compilerOptions": {
-    "jsx": "react"
-  },
-  "compilerOptions": {
-    "jsx": "react"
-  },
   // Note: This config is only used to help editors like VS Code understand/resolve
   // parts, the actual transpilation is done by babel. Any compiler configuration in
   // here will be ignored.
-  "include": ["./node_modules/@sanity/base/types/**/*.ts", "./**/*.ts", "./**/*.tsx", "layouts/1920X1080/index.ts", "layouts/twitter/index.tsx", "sanity.config.js", "layouts/1920X1080/deafult.jsx"], "layouts/1920X1080/index.js"
+  "include": ["./node_modules/@sanity/base/types/**/*.ts", "./**/*.ts", "./**/*.tsx", "layouts/1920X1080/index.ts", "layouts/twitter/index.tsx", "sanity.config.js", "layouts/1920X1080/deafult.jsx", "layouts/1920X1080/index.js"]
 }


### PR DESCRIPTION
## Description

This PR fixes/ #170  bug, sanity/tsconfig.json throws an error so `sanity start` unable to execute.

## Minor formatting update

- [x] 🐛 Bug Fix

## Changes Screenshot
![image](https://github.com/open-sauced/landing-page/assets/65410458/0689cbaf-ac71-4a10-bd51-3b63e1f92d73)

## Added tests?

- [x] 🙅 no, because they aren't needed

## Added to documentation?

- [x] 🙅 no documentation needed