### PR TITLE
fix: improved readability and easier navigation for blogposts

### DIFF
--- a/components/sections/blog/components/Post.tsx
+++ b/components/sections/blog/components/Post.tsx
@@ -59,7 +59,11 @@ const Post: FC<PostProps> = ({ data, featured }): ReactElement => {
         ))}
       </div>
       <div className=" min-h-[55px] largeTablet:min-h-[90px]">
-        <LocalTypography featured={featured} variant="title">{title}</LocalTypography>
+        <LocalTypography featured={featured} variant="title">
+          <a href={href} className="hover:text-brandOrange hover:decoration-brandOrange transition-all">
+            {title}
+          </a>
+        </LocalTypography>
       </div>
       <div className="flex items-center pb-6 largeTablet:pb-10 ">
         <div className="flex-shrink-0 mr-2">

--- a/components/sections/changelog/Changelog.tsx
+++ b/components/sections/changelog/Changelog.tsx
@@ -53,7 +53,7 @@ const Changelog: FC<ChangelogProps> = ({
             <IoMdGitCommit className="absolute -left-3 rounded-3xl text-2xl p-1  text-white bg-gradient-to-tr from-[#ED5432] to-[#EDA232] drop-shadow-[0_0_4px_#ED5432]" />
           </span>
           <Typography alignLarge="left" variant="title3">
-            <a href={`/changelog/${slug?.current}`} className="hover:text-brandOrange hover:underline hover:decoration-brandOrange">
+            <a href={`/changelog/${slug?.current}`} className="hover:text-brandOrange hover:decoration-brandOrange transition-all">
               {title}
             </a>
           </Typography>

--- a/styles/blog_text_content_wrapper.css
+++ b/styles/blog_text_content_wrapper.css
@@ -56,7 +56,6 @@
   font-size: 1.125rem;
   line-height: 1.75rem;
   letter-spacing: -0.02em;
-  opacity: 0.7;
 }
 
 .contentWrapper a {
@@ -76,12 +75,12 @@
   font-size: 1.125rem;
   line-height: 1.75rem;
   letter-spacing: -0.02em;
-  opacity: 0.7;
   list-style: disc;
 }
 
 .contentWrapper>ol {
   padding-left: 24px;
+  list-style: auto;
 }
 
 .contentWrapper>ol>li {
@@ -89,5 +88,4 @@
   font-size: 1.125rem;
   line-height: 1.75rem;
   letter-spacing: -0.02em;
-  opacity: 0.7;
 }


### PR DESCRIPTION
## Description

This PR removes some opacity styles applied to the blogposts content that was causing it to be less readable. Ordered lists now also appear as numbered lists.

It also adds links to blogpost titles on the blog page, to make it easier for users to access the posts.

## Related Tickets & Documents
N/A

## Mobile & Desktop Screenshots/Recordings
No size changes that require a mobile view.

BEFORE --> content had opacity set at 70%
<img width="1000" alt="image" src="https://github.com/open-sauced/landing-page/assets/27322879/3421c637-529e-43b9-a6b5-11d1f8d0d971">

AFTER --> now content has opacity set at 100%
<img width="1000" alt="image" src="https://github.com/open-sauced/landing-page/assets/27322879/68970bff-da0a-455b-b3ab-e502fc139dc8">



## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [X] Tier 4

## [optional] Are there any post-deployment tasks we need to perform?
N/A


## [optional] What gif best describes this PR or how it makes you feel?
![read-beauty-and-the-beast-gif](https://github.com/open-sauced/landing-page/assets/27322879/2047b122-0d85-4010-adcb-a92fa7744d59)


