### PR TITLE
Changed typography on changelog to dark mode

### DIFF
--- a/components/sections/changelog/Changelog.tsx
+++ b/components/sections/changelog/Changelog.tsx
@@ -99,7 +99,7 @@ const Changelog: FC<ChangelogProps> = ({
         <div style={containerHeightStyle}>
           <div className="relative" ref={contentRef}>
             <ReactMarkdown
-              className="prose prose-headings:text-textPrimary prose-li:text-textPrimary prose-p:text-textPrimary prose-ul:text-textPrimary prose-p:text-base prose-strong:text-textPrimary prose-img:rounded-md">
+              className="prose prose-invert prose-img:rounded-md">
               {changelogContent}
             </ReactMarkdown>
           </div>

--- a/pages/changelog/[slug].tsx
+++ b/pages/changelog/[slug].tsx
@@ -51,7 +51,7 @@ export default function ChangelogPage({ changelog, commonData, latestChanges } :
         url={`https://opensauced.pizza/changelog/${changelog.slug?.current}`}
       /> 
       <ReactMarkdown
-        className="mx-auto mb-24 leading-loose prose prose-md prose-headings:text-textPrimary prose-p:text-textPrimary prose-img:mx-auto prose-img:rounded-md prose-li:text-textPrimary prose-ul:text-textPrimary prose-p:text-base prose-strong:text-textPrimary"
+        className="mx-auto mb-24 leading-loose prose prose-md prose-headings:text-textPrimary prose-a:text-textPrimary prose-p:text-textPrimary prose-img:mx-auto prose-img:rounded-md prose-li:text-textPrimary prose-ul:text-textPrimary prose-p:text-base prose-strong:text-textPrimary"
       >
         {changelog.changelogContent}
       </ReactMarkdown>

--- a/pages/changelog/[slug].tsx
+++ b/pages/changelog/[slug].tsx
@@ -51,7 +51,7 @@ export default function ChangelogPage({ changelog, commonData, latestChanges } :
         url={`https://opensauced.pizza/changelog/${changelog.slug?.current}`}
       /> 
       <ReactMarkdown
-        className="mx-auto mb-24 leading-loose prose prose-md prose-headings:text-textPrimary prose-a:text-textPrimary prose-p:text-textPrimary prose-img:mx-auto prose-img:rounded-md prose-li:text-textPrimary prose-ul:text-textPrimary prose-p:text-base prose-strong:text-textPrimary"
+        className="prose-invert mx-auto mb-24 leading-loose prose prose-md prose-img:mx-auto prose-img:rounded-md"
       >
         {changelog.changelogContent}
       </ReactMarkdown>

--- a/types/schema.ts
+++ b/types/schema.ts
@@ -823,7 +823,7 @@ export interface SanityChangelog extends SanityDocument {
   /**
    * Changelog Summary — `string`
    *
-   * Please enter a short (less than 30 characters) summary of the changelog entry.
+   * Please enter a short (less than 50 characters) summary of the changelog entry.
    */
   summary?: string
 


### PR DESCRIPTION
## Description
Added `prose-invert` to the changelog body component to make typography dark mode, and removed previous hacky attempts at making text white.

## Related Tickets & Documents
closes #256

## Mobile & Desktop Screenshots/Recordings
Before:
Very subtle, but there's links in the text that the user can't see because they are black by default.
<img width="900" alt="image" src="https://github.com/open-sauced/landing-page/assets/27322879/47277526-2fa9-4a0c-a4d0-afa01c7fed51">


After:
links and text are visible because of default dark mode theme
<img width="900" alt="image" src="https://github.com/open-sauced/landing-page/assets/27322879/dd9e822f-d362-4e2c-9899-491ac214a994">


## Steps to QA
1. Go to https://opensauced.pizza/changelog
2. Open any changelog item and notice the text is fully readable now


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [ X] Tier 4

## [optional] Are there any post-deployment tasks we need to perform?
-


## [optional] What gif best describes this PR or how it makes you feel?
![tired-charles-barkley-gif-by-nba-on-tnt](https://github.com/open-sauced/landing-page/assets/27322879/949dbe75-12af-49f9-b2c6-0bfb640eacad)
