### PR TITLE
Replicated the changelog schema on the lunchweek page

### DIFF
--- a/components/sections/lunchweek/Background.tsx
+++ b/components/sections/lunchweek/Background.tsx
@@ -1,0 +1,35 @@
+import React, { FC } from 'react'
+import Image from 'next/image'
+
+// Static Assets
+import StrokeL5 from '../../../public/background-strokes/stroke_l_5.svg'
+import StrokeR4 from '../../../public/background-strokes/stroke_r_4.svg'
+import StrokeMobile1 from '../../../public/background-strokes/stroke_mobile_1.svg'
+
+interface BackgroundProps {
+  children: React.ReactNode
+}
+
+const Background: FC<BackgroundProps> = ({ children }) => {
+  return (
+    <div className="bg-darkBG text-white h-fit relative">
+      <div className="absolute hidden largeTablet:block largeTablet:top-[0rem] largeTablet:right-0">
+        <Image alt="Doodles" src={StrokeR4} />
+      </div>
+
+      <div className="absolute hidden largeTablet:block largeTablet:top-[1rem] largeTablet:left-0">
+        <Image alt="Doodles" src={StrokeL5} />
+      </div>
+
+      {/* MOBILE */}
+
+      <div className="absolute top-0 right-0  largeTablet:hidden">
+        <Image alt="Doodles" src={StrokeMobile1} />
+      </div>
+
+      <div className="relative">{children}</div>
+    </div>
+  )
+}
+
+export default Background

--- a/components/sections/lunchweek/Changelog.tsx
+++ b/components/sections/lunchweek/Changelog.tsx
@@ -1,0 +1,141 @@
+import React, { FC, useRef, useState } from 'react'
+import { Typography } from '../../common/text'
+import GradientBorderWrapper from '../../common/GradientBorderWrapper'
+import { IoMdGitCommit } from 'react-icons/io'
+import ReactMarkdown from 'react-markdown'
+import { MdOutlineExpandMore } from 'react-icons/md'
+import { SanityChangelog } from '../../../types/schema'
+import moment from 'moment'
+
+import Link from 'next/link'
+
+interface ChangelogProps {
+  changelog: SanityChangelog
+  index: number
+  count: number
+}
+
+const Changelog: FC<ChangelogProps> = ({
+  changelog: { title, date, changelogCategory, changelogContent, topics, slug },
+  index,
+  count,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  // function to expand the changelog
+  const expandChangelog = () => {
+    setIsExpanded(!isExpanded)
+  }
+
+  const containerHeightStyle = {
+    overflow: 'hidden',
+    transition: 'height 0.5s ease-in-out',
+    height: isExpanded ? `${contentRef.current?.clientHeight}px` : '360px',
+  }
+
+  // check if the changelog content has an image
+/*   const hasImageInContent = changelogContent.includes('![image](') */
+
+  // check the line of the changelog content
+/*   const lineCount = changelogContent.split('\n').length */
+
+  return (
+    <article
+      className={`flex pb-24 gap-x-10 h-full relative border-textPrimary border-opacity-50 ${
+        index + 1 === count ? '' : 'border-l-2'
+      }`}
+    >
+      <div className="relative pb-28">
+        <section
+          className={`hidden self-start sticky top-8 tablet:flex flex-1 pl-10 max-w-md flex-col `}
+        >
+          <span>
+            <IoMdGitCommit className="absolute -left-3 rounded-3xl text-2xl p-1  text-white bg-gradient-to-tr from-[#ED5432] to-[#EDA232] drop-shadow-[0_0_4px_#ED5432]" />
+          </span>
+          <Typography alignLarge="left" variant="title3">
+            <Link
+              href={`/changelog/${slug?.current}`}
+              className="hover:text-brandOrange hover:decoration-brandOrange transition-all"
+            >
+              {title}
+            </Link>
+          </Typography>
+          <span className="py-4">
+            <Typography alignLarge="left" variant="body4">
+              {moment(date).format('DD MMM YYYY')}
+            </Typography>
+          </span>
+          <div className="flex gap-3">
+            {topics &&
+              topics.map((category, index) => (
+                <GradientBorderWrapper
+                  key={index}
+                  style={{ borderRadius: '16px' }}
+                >
+                  <div className="bg-darkBG rounded-2xl text-sm px-2 py-1">
+                    {category}
+                  </div>
+                </GradientBorderWrapper>
+              ))}
+          </div>
+        </section>
+      </div>
+
+      <section
+        className={`flex-1 relative pb-10 tablet:border-0 tablet:pl-0 pl-6 ${
+          index + 1 === count ? '' : 'border-l-2'
+        }`}
+      >
+        <div className="tablet:hidden relative flex-col flex gap-y-2 pb-4">
+          <span className=" -left-6 -top-4 absolute">
+            <IoMdGitCommit className="absolute -left-4 top-4 bg-darkBG text-3xl" />
+          </span>
+          <Typography alignLarge="left" variant="title3">
+            {title}
+          </Typography>
+          <Typography alignLarge="left" variant="body4">
+            {moment(date).format('DD MMM YYYY')}
+          </Typography>
+          <div className="flex gap-2">
+            {topics &&
+              topics.map((category, index) => (
+                <GradientBorderWrapper
+                  key={index}
+                  style={{ borderRadius: '16px' }}
+                >
+                  <div className="bg-darkBG rounded-2xl text-sm px-2 py-1">
+                    {category}
+                  </div>
+                </GradientBorderWrapper>
+              ))}
+          </div>
+        </div>
+
+        <div style={containerHeightStyle}>
+          <div className="relative" ref={contentRef}>
+            <ReactMarkdown
+              className="prose prose-invert prose-img:rounded-md">
+              {changelogContent}
+            </ReactMarkdown>
+          </div>
+        </div>
+        {/* (hasImageInContent || changelogContent.length > 260) && */ (
+          <button
+            onClick={expandChangelog}
+            className="text-textPrimary font-bold flex items-center mt-8 gap-x-2 transition-all hover:text-brandOrange"
+          >
+            {isExpanded ? 'Collapse' : 'See more'}
+            {isExpanded ? (
+              <MdOutlineExpandMore className="transform rotate-180" />
+            ) : (
+              <MdOutlineExpandMore />
+            )}
+          </button>
+        )}
+      </section>
+    </article>
+  )
+}
+
+export default Changelog

--- a/components/sections/lunchweek/Changelogs.tsx
+++ b/components/sections/lunchweek/Changelogs.tsx
@@ -1,0 +1,85 @@
+import React, { FC, useEffect, useState } from 'react'
+import SectionWrapper from '../../common/layout/SectionWrapper'
+import Changelog from './Changelog'
+import { getChangelog } from '../../../lib/sanity'
+import { SanityChangelog } from '../../../types/schema'
+import GradientBorderWrapper from '../../common/GradientBorderWrapper'
+
+interface ChangelogsProps {
+  totalChangelogCount: number
+}
+
+const Changelogs: FC<ChangelogsProps> = ({ totalChangelogCount }) => {
+  const [changelogs, setChangelogs] = useState<any[]>([])
+  const [limit, setLimit] = useState(5)
+
+  const loadMore = () => setLimit(limit + 5)
+
+  useEffect(() => {
+    const getChangeLog = async () => {
+      setChangelogs([
+        {
+          date: '2024-04-24',
+          changelogContent:
+            "![image](https://cdn.sanity.io/images/r7m53vrk/production/7352f7c42cd131c3455710e6e24a643039367153-1687x838.png)\n\n\nImagine if you could access all the knowledge of the entire git history of thousands of GitHub repositories in one place, all at once. Now imagine if you could ask any questions about it... and get real answers.\n\nWell, imagine no more, because StarSearch is coming!\n\nSoon, you'll be able to use StarSearch to find subject matter experts based on their actual commits, identify true, key contributors among all the noise, and get information on any contributor's github activity.\n\nWe are working on the final details, but in the meantime you can join our waitlist and be the first one to try it out!\n\n[Join the Waitlist](https://app.opensauced.pizza/star-search/waitlist)\n\n\n![image](https://cdn.sanity.io/images/r7m53vrk/production/ebc45c92b210939a0683183da45d9f458719c3d4-1687x838.png)",
+          summary:
+            'We are working on something new... sign up and be the first one to see  👀✨',
+          _type: 'changelog',
+          changelogCategory: {
+            _type: 'changelogCategory',
+            changelogCategory: {
+              _ref: '246f4daf-5df6-4682-af8e-9ec94d74ca9d',
+              _type: 'reference',
+            },
+          },
+          _updatedAt: '2024-05-01T03:49:30Z',
+          slug: {
+            current: 'starsearch-waitlist',
+            _type: 'slug',
+          },
+          _createdAt: '2024-04-30T02:03:44Z',
+          _id: '13ea5079-5389-46c8-a934-e346fdd885e1',
+          title: 'Join the StarSearch Waitlist  ✨',
+          _rev: 'DcneF66P6QscvZLjoADf4z',
+          launchDay: '11/11/1111',
+          blogLink: '',
+          videoLink: '',
+          twitterLink: '',
+        },
+      ])
+    }
+    getChangeLog()
+  }, [limit])
+
+  return (
+    <section>
+      <SectionWrapper>
+        <main className="flex flex-col">
+          {changelogs.length > 0 &&
+            changelogs.map((changelog, index) => (
+              <Changelog
+                count={changelogs.length}
+                index={index}
+                key={changelog._id}
+                changelog={changelog}
+              />
+            ))}
+        </main>
+        {changelogs.length < totalChangelogCount && (
+          <div className="flex justify-center pt-20 pb-36">
+            <GradientBorderWrapper>
+              <button
+                className="bg-brandOrange px-3 py-1 rounded-md font-bold"
+                onClick={loadMore}
+              >
+                Load More
+              </button>
+            </GradientBorderWrapper>
+          </div>
+        )}
+      </SectionWrapper>
+    </section>
+  )
+}
+
+export default Changelogs

--- a/components/sections/lunchweek/Hero.tsx
+++ b/components/sections/lunchweek/Hero.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Heading, Typography } from '../../common/text'
+
+const Hero = () => {
+  return (
+    <section className="z-40 py-24 tablet:py-36 border-slate-800 relative flex flex-col gap-y-5 from-transparent via-red-800 to-transparent">
+      <Heading alignSmall="center" >
+        $yellow-to-orangeLunch Week$yellow-to-orange
+      </Heading>
+      <Typography alignSmall="center" variant="subheading">
+        Incoming feautures!
+      </Typography>
+    </section>
+  )
+}
+
+export default Hero

--- a/components/sections/lunchweek/IndividualHero.tsx
+++ b/components/sections/lunchweek/IndividualHero.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Heading, Typography } from '../../common/text'
+import GradientBorderWrapper from '../../common/GradientBorderWrapper'
+import SocialShare from '../../common/SocialShare'
+import moment from 'moment'
+
+const Hero = ({
+  title,
+  topics,
+  date,
+  url,
+}: {
+  title: string
+  topics: string[]
+  date: string
+  url: string
+}) => {
+  return (
+    <section className="items-center py-16 max-w-3xl mx-auto tablet:py-24 border-slate-800 relative flex flex-col gap-y-8 from-transparent via-red-800 to-transparent">
+      <Typography alignSmall="center" variant="subheading">
+        {moment(date).format('DD MMM YYYY')}
+      </Typography>
+      <Heading alignSmall="center">{title}</Heading>
+      <SocialShare url={url} size="lg" gap={6} hackerNews />
+      <div className="flex gap-3 mx-auto">
+        {topics &&
+          topics.map((category, index) => (
+            <GradientBorderWrapper key={index} style={{ borderRadius: '16px' }}>
+              <div className="bg-darkBG rounded-2xl text-sm px-2 py-1">
+                {category}
+              </div>
+            </GradientBorderWrapper>
+          ))}
+      </div>
+    </section>
+  )
+}
+
+export default Hero

--- a/pages/lunchweek/[slug].tsx
+++ b/pages/lunchweek/[slug].tsx
@@ -1,0 +1,73 @@
+import { ReactMarkdown } from "react-markdown/lib/react-markdown";
+
+import { Button } from "../../components/common";
+import PageLayout from "../../components/common/layout/PageLayout";
+import Changelog from "../../components/sections/lunchweek/Changelog";
+import Background from "../../components/sections/lunchweek/Background";
+import SectionWrapper from "../../components/common/layout/SectionWrapper";
+import IndividualHero from "../../components/sections/lunchweek/IndividualHero";
+
+import { SanityChangelog, SanityFooter, SanityNavigation, SanitySeo } from "../../types/schema";
+import { getCommonData, getChangelogBySlug, getLatestChangelogsExceptSlug } from "../../lib/sanity";
+
+export async function getServerSideProps({ params } : { params: { slug: string }}) {
+  if (!params.slug) { 
+    return { notFound: true };
+  }
+
+  const changelog = await getChangelogBySlug(params.slug);
+
+  // there's no associated log to the slug given
+  if (!changelog) {
+    return { notFound: true };
+  }
+
+  const commonData = await getCommonData();
+  const latestChanges = await getLatestChangelogsExceptSlug(params.slug);
+
+  return { props: { changelog, commonData, latestChanges }};
+}
+
+export default function ChangelogPage({ changelog, commonData, latestChanges } : { 
+  changelog: SanityChangelog,  
+  commonData: {
+    navigationLinks: SanityNavigation[],
+    seoData: SanitySeo,
+    footer: SanityFooter[]
+  },
+  latestChanges: SanityChangelog[],
+}) {
+
+  return (
+    <PageLayout
+      seoData={commonData.seoData}
+      navigationURLs={commonData.navigationLinks}
+      BackgroundWrapper={Background}
+    >
+      <IndividualHero 
+        title={changelog.title ?? "Test"} 
+        topics={changelog.topics ?? []} 
+        date={changelog.date ?? "2001-02-02"} 
+        url={`https://opensauced.pizza/changelog/${changelog.slug?.current}`}
+      /> 
+      <ReactMarkdown
+        className="prose-invert mx-auto mb-24 leading-loose prose prose-md prose-img:mx-auto prose-img:rounded-md"
+      >
+        {changelog.changelogContent}
+      </ReactMarkdown>
+
+      <SectionWrapper>
+        <section className="flex flex-col py-24 border-t-2 border-brandOrange">
+          {latestChanges.length > 0 && latestChanges.map((changelog, index) => (
+            <Changelog count={latestChanges.length} index={index} key={changelog._id} changelog={changelog}/>
+          ))}
+          <span className="mx-auto">
+            <Button href="/changelog">View More Changes</Button>
+          </span>
+        </section>
+      </SectionWrapper>
+
+    </PageLayout>
+  )
+}
+

--- a/pages/lunchweek/index.tsx
+++ b/pages/lunchweek/index.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import Hero from '../../components/sections/lunchweek/Hero'
+import Changelogs from '../../components/sections/lunchweek/Changelogs'
+import PageLayout from '../../components/common/layout/PageLayout'
+import { getAllChangelog, getCommonData } from '../../lib/sanity'
+import { NextPage } from 'next'
+import { SanityFooter, SanityNavigation, SanitySeo } from '../../types/schema'
+import Background from '../../components/sections/lunchweek/Background'
+
+interface BlogsPageProps {
+  data: {
+    commonData: {
+      navigationLinks: SanityNavigation[]
+      seoData: SanitySeo
+      footer: SanityFooter[]
+    }
+    totalChangelogCount: number
+  }
+}
+
+const Index: NextPage<BlogsPageProps> = ({
+  data: {
+    commonData: { navigationLinks, seoData },
+    totalChangelogCount,
+  },
+}) => {
+  return (
+    <PageLayout
+      seoData={seoData}
+      navigationURLs={navigationLinks}
+      BackgroundWrapper={Background}
+    >
+      <Hero />
+      <Changelogs totalChangelogCount={totalChangelogCount} />
+    </PageLayout>
+  )
+}
+
+export default Index
+
+export async function getStaticProps() {
+  const [commonData, AllChangelog] = await Promise.all([
+    getCommonData(),
+    getAllChangelog(),
+  ])
+
+  const totalChangelogCount = AllChangelog.length
+  const data = { commonData, totalChangelogCount }
+
+  return {
+    props: {
+      data,
+    },
+    revalidate: 30,
+  }
+}


### PR DESCRIPTION
This PR adds the replicated changelog schema into the lunchweek feature to have a structure into which data about the lunchweek features can be added


Feauture #267


## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [x] Tier 3
- [ ] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
