### PR TITLE
Fix: removed duplicate subscribe form from pages

### DIFF
--- a/components/common/layout/PageLayout.tsx
+++ b/components/common/layout/PageLayout.tsx
@@ -46,7 +46,7 @@ const PageLayout: FC<PageLayoutProps> = ({
         <PHBadge/>
         {!pressPage && <Header navigationItems={navigationURLs} />}
         <div>{children}</div>
-        {!pressPage && !homePage && <Subscribe />}
+       
         <Footer pressPage={pressPage} />
       </BackgroundWrapper>
     </div>


### PR DESCRIPTION
## Description

This PR resolves the issue #270 by fixing the problem of having two subscribe forms on the mobile landing page. It ensures that only one subscribe form is displayed, improving the layout and user experience on mobile  and larger devices.


## Related Tickets & Documents

Fixes #270


## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

1. Navigate to the mobile landing page.
2. Verify that only one subscribe form is displayed.
3. Check the layout and spacing on different mobile devices.
4. Confirm that the subscribe form functions correctly.
5. Test the responsiveness of the page.



## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [ ] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

![excited gif](https://giphy.com/clips/theoffice-the-office-peacock-tv-show-G96zgIcQn1L2xpmdxi) 


<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
