### PR TITLE
Menu on mobile no longer shows up behind content

### DIFF
--- a/components/sections/navigation/DropdownMenu.tsx
+++ b/components/sections/navigation/DropdownMenu.tsx
@@ -27,7 +27,7 @@ const DropdownMenu = ({ menuItems, className, label }: DropdownMenuProps) => {
             <Image src={open ? MobileCloseMenu : MobileMenu} alt="Menu" />
           </Menu.Button>
 
-          <Menu.Items className="absolute z-40 h-fit min-h-[470px] right-6 left-6 mt-6 bg-gradient-to-r from-[#ED5432] to-[#EDA232] py-9 px-7 rounded-lg">
+          <Menu.Items className="absolute z-50 h-fit min-h-[470px] right-6 left-6 mt-6 bg-gradient-to-r from-[#ED5432] to-[#EDA232] py-9 px-7 rounded-lg">
             <p className="font-bold text-textPrimary text-xs opacity-70 tracking-[0.2em] pb-8">
               MENU
             </p>


### PR DESCRIPTION
## Description
FIxed z-index so that menu on mobile shows up on top of the content.

### BEFORE 
<img width="200" alt="image" src="https://github.com/open-sauced/landing-page/assets/27322879/97a8099b-fa07-4865-84aa-1ddf234fae56">

### AFTER
<img width="200" alt="image" src="https://github.com/open-sauced/landing-page/assets/27322879/a57e0a64-d085-49b3-aa3a-0d25c3d529da">


## Related Tickets & Documents
#284 




## Steps to QA
1. go to /lunchweek on mobile
2. open the menu

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [ ] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?
