### PR TITLE
fix: Update Product Hunt badge links

### DIFF
--- a/components/common/product-hunt/PHBadge.tsx
+++ b/components/common/product-hunt/PHBadge.tsx
@@ -3,12 +3,12 @@ import React from 'react'
 const PHBadge = () => {
   return (
     <div className="fixed z-50 bottom-6 right-6 tablet:bottom-8 tablet:right-9 ">
-      <a href="https://www.producthunt.com/posts/starsearch?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-opensauced"
+      <a href="https://www.producthunt.com/posts/starsearch?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-starsearch"
         target="_blank">
         <img
           className="w-36 tablet:w-60 tablet:h-12"
-          src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=419250&theme=light"
-          alt="OpenSauced - Optimize&#0032;Your&#0032;Open&#0032;Source&#0032;Project&#0032;with&#0032;Deep&#0032;Insights | Product Hunt"
+          src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=455549&theme=light"
+          alt="StarSearch - Copilot, but for git history | Product Hunt"
         />
       </a>
     </div>

--- a/components/common/product-hunt/PHBadgeDark.tsx
+++ b/components/common/product-hunt/PHBadgeDark.tsx
@@ -4,13 +4,13 @@ const PHBadgeDark = () => {
   return (
     <div className="w-fit -ml-2">
       <a
-        href="https://www.producthunt.com/posts/starsearch?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-opensauced"
+        href="https://www.producthunt.com/posts/starsearch?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-starsearch"
         target="_blank"
       >
         <img
           className="w-36 tablet:w-60 tablet:h-12"
-          src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=419250&theme=dark"
-          alt="OpenSauced - Optimize&#0032;Your&#0032;Open&#0032;Source&#0032;Project&#0032;with&#0032;Deep&#0032;Insights | Product Hunt"
+          src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=455549&theme=dark"
+          alt="StarSearch - Copilot, but for git history | Product Hunt"
         />
       </a>
     </div>


### PR DESCRIPTION
Related to #288

Updates the Product Hunt badge links and images in the `PHBadge.tsx` and `PHBadgeDark.tsx` components to reflect the new product launch details.
- Changes the `href` attribute in both components to point to the new Product Hunt link for StarSearch.
- Updates the `src` attribute of the `img` tag in both components to use the new image sources for the light and dark themes, respectively.
- Adjusts the `alt` text in both components to accurately describe the new product as "StarSearch - Copilot, but for git history | Product Hunt".


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/open-sauced/landing-page/issues/288?shareId=708b5b1f-7ab4-485d-93dd-1785f4d5a596).