### PR TITLE
fix: now doc site rewrites work for all docs URLs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -25,16 +25,11 @@ const nextConfig = {
       },
       {
         source: '/docs/:path*',
-        destination: 'https://main--saucedocs.netlify.app/:path*',
+        destination: 'https://saucedocs.netlify.app/:path*/',
       },
-      {
-        source: '/docs/',
-        destination: 'https://main--saucedocs.netlify.app/',
-      }
-    ];
+    ]
   },
-  skipTrailingSlashRedirect: true, 
-
+  skipTrailingSlashRedirect: true,
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
## Description

Fixes the rewrite rules for the docs site which now resides under https://opensauced.pizza/docs.

The issue was a missing trailing slash in the rewrite, and the additional rule for the root of the docs site to `/docs` was unnecessary.

## Related Tickets & Documents

Fixes #300

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

1. Visit https://deploy-preview-307--opensauced-landing.netlify.app/docs. The docs site loads.
2. Refresh the page, the docs site still loads.
3. Navigate to https://deploy-preview-307--opensauced-landing.netlify.app/docs/maintainers/maintainers-guide-to-open-sauced/. The page loads.
4. Refresh the https://deploy-preview-307--opensauced-landing.netlify.app/docs/maintainers/maintainers-guide-to-open-sauced/ page. The page loads.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/tZB5MG7OOPuZIAcPZZ/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
