### PR TITLE
feat: better blog list spacing 

### DIFF
--- a/components/sections/blog/[slug]/BlogTextContent.tsx
+++ b/components/sections/blog/[slug]/BlogTextContent.tsx
@@ -7,7 +7,16 @@ interface BlogTextContentProps {
 
 const BlogTextContent: FC<BlogTextContentProps> = ({ data }): ReactElement => {
   return (
-    <div className="prose prose-invert w-full max-w-[780px] mt-6 largeTablet:mt-24 text-textPrimary contentWrapper text-lg ">
+    <div 
+      className="
+        w-full max-w-[780px] mt-6 largeTablet:mt-24 text-textPrimary contentWrapper text-lg
+        prose prose-invert space-y-0 
+        prose-ol:flex prose-ol:flex-col prose-ol:gap-0
+        prose-ul:flex prose-ul:flex-col prose-ul:gap-0
+        prose-headings:font-bold prose-headings:py-4
+        prose-a:no-underline
+      "
+    >
       <ReactMarkdown>
         {data}
       </ReactMarkdown>


### PR DESCRIPTION
## Description

Implements the previous styling from before #341 was merged, alongside tighter spacing for lists.
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents

Closes #340 
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings
**Left: PR | Right: Prod**
![image](https://github.com/user-attachments/assets/0945468c-96ef-4c93-90ee-f5f204eea66b)

<!-- Visual changes require screenshots -->


## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
