### PR TITLE
fix: `/cli` CTA for mobile view

### DIFF
--- a/pages/cli/index.tsx
+++ b/pages/cli/index.tsx
@@ -5,7 +5,7 @@ import { getCommonData } from '../../lib/sanity';
 import Footer from '../../components/sections/Footer';
 import { Heading, Typography } from '../../components/common/text';
 import { Button } from '../../components/common';
-import { TbArrowNarrowRight, TbCopy } from "react-icons/tb";
+import { TbArrowNarrowRight } from "react-icons/tb";
 import Image from 'next/image';
 
 export async function getStaticProps() {
@@ -40,12 +40,11 @@ export default function CliPage({ commonData }: CliPageProps) {
             Try the <code className='px-2'>pizza</code> CLI and access OpenSauced features right from your terminal. Autogenerate your CODEOWNERS and contributor insights in seconds.
           </Typography>
 
-          <div className='flex gap-4 items-center'>
-            <code className='p-4 bg-neutral-800 rounded-xl'>
+          <div className='flex flex-col gap-4 items-center'>
+            <code className='p-4 bg-neutral-800 rounded-xl text-sm largeTablet:text-md'>
               brew install open-sauced/tap/pizza 
             </code>
-            <p>or</p>
-            <Button href='https://github.com/open-sauced/pizza-cli/releases'>Download for Mac</Button>
+            <Button href='https://github.com/open-sauced/pizza-cli/releases'>Download for Mac</Button> 
           </div>
 
           <a href="https://github.com/open-sauced/pizza-cli?tab=readme-ov-file#-install" className='hover:underline'>


### PR DESCRIPTION
## Description

Changes the code and CTA display order to ensure it doesn't overflow on mobile
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents

Closes #363 
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings
![image](https://github.com/user-attachments/assets/ba2d5af8-d8dd-4f38-923e-a08d829cd68b)

<!-- Visual changes require screenshots -->


## Steps to QA

1. Go to `/cli` on mobile view
2. Ensure no detail is overflowing on the page
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
3. Do this thing
4. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
